### PR TITLE
fix import of config.py and episode_matcher.py

### DIFF
--- a/mkv_episode_matcher/__main__.py
+++ b/mkv_episode_matcher/__main__.py
@@ -4,7 +4,7 @@ import os
 
 from loguru import logger
 
-from config import get_config, set_config
+from mkv_episode_matcher.config import get_config, set_config
 
 # Log the start of the application
 logger.info("Starting the application")
@@ -170,7 +170,7 @@ def main():
     logger.info("Configuration set")
 
     # Process the show
-    from episode_matcher import process_show
+    from mkv_episode_matcher.episode_matcher import process_show
 
     process_show(args.season, dry_run=args.dry_run, get_subs=args.get_subs)
     logger.info("Show processing completed")

--- a/mkv_episode_matcher/__main__.py
+++ b/mkv_episode_matcher/__main__.py
@@ -4,7 +4,7 @@ import os
 
 from loguru import logger
 
-from .config import get_config, set_config
+from config import get_config, set_config
 
 # Log the start of the application
 logger.info("Starting the application")
@@ -170,7 +170,7 @@ def main():
     logger.info("Configuration set")
 
     # Process the show
-    from .episode_matcher import process_show
+    from episode_matcher import process_show
 
     process_show(args.season, dry_run=args.dry_run, get_subs=args.get_subs)
     logger.info("Show processing completed")


### PR DESCRIPTION
Issue:
When executing the Script, I am getting an exception, that the modules could not be found:

```
Traceback (most recent call last):
  File "C:\Users\{USER}\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\mkv_episode_matcher\__main__.py", line 7, in <module>
    from .config import get_config, set_config
ImportError: attempted relative import with no known parent package
```

and
```
2024-07-25 12:04:33.584 | ERROR    | __main__:<module>:181 - An error has been caught in function '<module>', process 'MainProcess' (8100), thread 'MainThread' (23780):
Traceback (most recent call last):

> File "C:\Users\{USER}\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\mkv_episode_matcher\__main__.py", line 181, in <module>
    main()
    └ <function main at 0x0000010856D40E00>
  File "C:\Users\{USER}\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\mkv_episode_matcher\__main__.py", line 173, in main
    from .episode_matcher import process_show

ImportError: attempted relative import with no known parent package
```

after removing the `.` infront of the module, the script could be executed.


