### PR TITLE
Fail reference_files check only when boolean get_subs = false

### DIFF
--- a/mkv_episode_matcher/episode_matcher.py
+++ b/mkv_episode_matcher/episode_matcher.py
@@ -32,7 +32,7 @@ def process_show(season=None, dry_run=False, get_subs=False):
     # Early check for reference files
     reference_dir = Path(CACHE_DIR) / "data" / show_name
     reference_files = list(reference_dir.glob("*.srt"))
-    if not reference_files:
+    if (not get_subs) and (not reference_files):
         logger.error(f"No reference subtitle files found in {reference_dir}")
         logger.info("Please download reference subtitles first")
         return


### PR DESCRIPTION
If get_subs = true, it seems program flow should continue when reference_files is empty, so the program might get the subs from opensubtitles.com. Currenty, the program halts because no subtitles exist in directory path ".mkv-episode-matcher\cache\data", but I want it to download the subtitles for me when I set get_subs = true. The workaround is to manually download the subtitles each time and unpack them, rename them, etc., into this folder, which is quite labor intensive.